### PR TITLE
Fix ClI in tagged releases

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -19,4 +19,5 @@ except VersionConflict:
 
 
 if __name__ == "__main__":
-    setup(use_pyscaffold=True)
+    # pyscaffold version required to get cli working again
+    setup(use_pyscaffold=True, setup_requires=['pyscaffold>=2.5a0,<2.6a0'])


### PR DESCRIPTION
Apparently this is required to get the cli working. I could not find anywhere why, but after this we should be able to get the cli again

closes #22 