### PR TITLE
fix: use unambiguous date and time formats in logs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,11 @@ Changelog
 =========
 
 
+Unreleased
+=============
+- Use unambiguous date and time formats in logs
+
+
 Version 2.0.4
 =============
 - Add --backward to cli

--- a/vds_api_client/vds_api_base.py
+++ b/vds_api_client/vds_api_base.py
@@ -21,7 +21,7 @@ def setup_logging(filelevel=10, streamlevel=20):
         fh = logging.FileHandler('vds_api.log')
         ch = logging.StreamHandler()
         formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)8s - %(funcName)s @ thr %(thread)05d' +
-                                      '  - %(message)s', datefmt='%Y/%m/%d %I:%M:%S')
+                                      '  - %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
         fh.setFormatter(formatter)
         ch.setFormatter(formatter)
         fh.setLevel(filelevel)


### PR DESCRIPTION
The logging date format used `%I` which is a 12-hour clock, without any AM/PM indicator. This tiny change makes it use 24-hour time. 

Also, logging used the date format `yyyy/mm/dd`, which is not common: the US swaps month and day in `yyyy/dd/mm`, so people (and computers) may interpret 2020/09/08 as August 9th rather than September 8th. Using `yyyy-mm-dd` with dashes fixes that.