### PR TITLE
Fix ROI area unit in string representation

### DIFF
--- a/.github/workflows/test-python-3-6.yml
+++ b/.github/workflows/test-python-3-6.yml
@@ -33,4 +33,4 @@ jobs:
         VDS_USER: ${{ secrets.VDS_USER }}
         VDS_PASS: ${{ secrets.VDS_PASS }}
       run: |
-        pytest
+        pytest tests

--- a/README.rst
+++ b/README.rst
@@ -324,10 +324,10 @@ easier using the client methods that allow you to filter the rois.
 
      # ID / DISPLAY # |  # Name #  |   # Area #   |  # Created at #  |       # Description #
     ===============================================================================================
-       25009  /  [X]  | Center     | 1.063e+09 ha | 2020-08-16 12:49 | Center pixels
-       25010  /  [X]  | Right      | 9.949e+08 ha | 2020-08-16 12:58 | Right side pixels
-       25011  /  [X]  | Bottom     | 6.616e+08 ha | 2020-08-16 12:59 | Bottom side pixels
-       30596  /  [ ]  | NewName    | 9.140e+07 ha | 2020-09-18 07:19 | Same rectangle
+       25009  /  [X]  | Center     | 1.063e+05 ha | 2020-08-16 12:49 | Center pixels
+       25010  /  [X]  | Right      | 9.949e+04 ha | 2020-08-16 12:58 | Right side pixels
+       25011  /  [X]  | Bottom     | 6.616e+04 ha | 2020-08-16 12:59 | Bottom side pixels
+       30596  /  [ ]  | NewName    | 9.140e+03 ha | 2020-09-18 07:19 | Same rectangle
 
 **Filters**
 
@@ -350,8 +350,8 @@ and give the corresponding ids:
 
      # ID / DISPLAY # |  # Name #  |   # Area #   |  # Created at #  |       # Description #
     ===============================================================================================
-       25010  /  [X]  | Right      | 9.949e+08 ha | 2020-08-16 12:58 | Right side pixels
-       25011  /  [X]  | Bottom     | 6.616e+08 ha | 2020-08-16 12:59 | Bottom side pixels
+       25010  /  [X]  | Right      | 9.949e+04 ha | 2020-08-16 12:58 | Right side pixels
+       25011  /  [X]  | Bottom     | 6.616e+04 ha | 2020-08-16 12:59 | Bottom side pixels
 
     [25010, 25011]
 
@@ -382,7 +382,7 @@ Updating an Roi's metadata is supported through the roi.update method:
 
      # ID / DISPLAY # |  # Name #  |   # Area #   |  # Created at #  |       # Description #
     ===============================================================================================
-       30596  /  [ ]  | New name   | 9.140e+07 ha | 2020-09-18 07:19 | New description
+       30596  /  [ ]  | New name   | 9.140e+03 ha | 2020-09-18 07:19 | New description
 
 
 **Deleting**

--- a/vds_api_client/types.py
+++ b/vds_api_client/types.py
@@ -226,8 +226,8 @@ class Rois(object):
     def __str__(self):
         if self.__bool__():
             nlen = max(max([len(r.name) for r in self._rois]), 10)  # max product length display
-            prod_ls = [(f' {roi.id:7d}  /  [{"X" if roi.display else " "}]  | {roi.name:{nlen}s} ' 
-                        f'| {roi.area:.3e} ha | {roi.created_at:%Y-%m-%d %H:%M} | {roi.description}')
+            prod_ls = [(f' {roi.id:7d}  /  [{"X" if roi.display else " "}]  | {roi.name:{nlen}s} '
+                        f'| {roi.area / 1e4 :.3e} ha | {roi.created_at:%Y-%m-%d %H:%M} | {roi.description}')
                        for roi in self._rois]
             body = '\n'.join(prod_ls)
         else:


### PR DESCRIPTION
This fixes the area displayed by `vds.rois`, e.g.:

```sh
>>> vds.rois

 # ID / DISPLAY # | # Name #  |   # Area #   |  # Created at #  | # Description #
=================================================================================================================
   18845  /  [X]  | Right     | 3.461e+04 ha | 2020-05-21 09:19 | Right side
   18846  /  [ ]  | Left      | 6.344e+07 ha | 2020-05-21 09:19 | Left side
```

API returns area in m^2, so we need to divide by `1e4` to get the number of hectares.

---

Closes #47 
