### PR TITLE
Check for 'data' key in status dict

### DIFF
--- a/src/vds_api_client/api_v2.py
+++ b/src/vds_api_client/api_v2.py
@@ -396,7 +396,8 @@ class VdsApiV2(VdsApiBase):
         status_url = f'https://{self.host}/api/v2/api-requests/{uuid}/status'
         self.logger.debug(f'Status request for UUID: {uuid}')
         status_dict = self.get_content(status_url)
-        while status_dict['percentage'] < 100 and status_dict['processing_status'] != 'Ready' and wait_for_complete:
+        while (status_dict['percentage'] < 100 or status_dict['processing_status'] != 'Ready'
+                or status_dict.get('data') is None) and wait_for_complete:
             time.sleep(self._wait_time)
             status_dict = self.get_content(status_url)
             _ = sys.stderr.write('\t' * 20 + '\b\r')


### PR DESCRIPTION
Potential fix for issues with incomplete status dict causing fails within queue_uuids_files - large orders keep failing due to the _uuid_status method returning before it actually should.

Changing check to OR to be more restrictive 