### PR TITLE
Remove dayfirst when parsing CSV files

### DIFF
--- a/src/vds_api_client/api_v2.py
+++ b/src/vds_api_client/api_v2.py
@@ -487,7 +487,7 @@ class VdsApiV2(VdsApiBase):
         for chunk in r.iter_content(2048):
             csv.write(chunk)
         csv.seek(0)
-        df = pd.read_csv(csv, index_col=0, parse_dates=True, dayfirst=True, comment='#')
+        df = pd.read_csv(csv, index_col=0, parse_dates=True, comment='#')
         csv.close()
         return df
 


### PR DESCRIPTION
Since pandas 2.0 the dayfirst setting caused short timeseries at the beginning of the month to be parsed with a US date format like this example which shows data from the first of April to the 12th of April 2015 but actually looks like data on every 4th of the month in the year 2015.

```

            SM-SMAP-LN-DESC_V003_100
date
2015-01-04                    0.3365
2015-02-04                       NaN
2015-03-04                    0.3275
2015-04-04                    0.3088
2015-05-04                    0.3138
2015-06-04                    0.3182
2015-07-04                       NaN
2015-08-04                    0.3054
2015-09-04                    0.3029
2015-10-04                       NaN
2015-11-04                    0.2695
2015-12-04                    0.2843
```

After this fix the same csv file is parsed correctly as

```
            SM-SMAP-LN-DESC_V003_100
date
2015-04-01                    0.3365
2015-04-02                       NaN
2015-04-03                    0.3275
2015-04-04                    0.3088
2015-04-05                    0.3138
2015-04-06                    0.3182
2015-04-07                       NaN
2015-04-08                    0.3054
2015-04-09                    0.3029
2015-04-10                       NaN
2015-04-11                    0.2695
2015-04-12                    0.2843
```