### PR TITLE
Add option to provide a Oauth Token via CLI or Env Variable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -96,6 +96,10 @@ And it is always a good idea to start with a test:
 
 Credentials
 -----------
+
+Username / password
+~~~~~~~~~~~~~~~~~~~
+
 For each api call using the cli, the credentials need to be supplied.
 These can be parsed along with the call by typing them explicitly like:
 
@@ -105,6 +109,48 @@ However, it is also convenient to store the credentials so they don't have to be
 typed each time. `Set the environment variables <https://www.schrodinger.com/kb/1842>`_
 ``$VDS_USER`` and ``$VDS_PASS``
 with the correct values to automatically fill in your credentials.
+
+
+Planet internal SSO
+~~~~~~~~~~~~~~~~~~~
+
+To use Planet SSO get a token using the following procedure
+
+- **Install:**
+  ::
+
+    pip install planet-auth-utils
+
+- **Login:**
+
+  Default login: opens browser for authorization and listens locally for callback.
+
+  ::
+
+    plauth oauth login
+
+- **Get Token:**
+
+  ::
+
+     plauth oauth print-access-token
+
+For each api call using the cli, the credentials need to be supplied.
+These can be parsed along with the call by typing them explicitly like:
+
+``$ vds-api -t $(plauth oauth print-access-token) [command]``
+
+However, it is also convenient to store the credentials so they don't have to be
+typed each time. `Set the environment variable <https://www.schrodinger.com/kb/1842>`_
+``$PL_VDS_OAUTH_TOKEN`` with the correct value to automatically fill in your credentials.
+
+This can be done in one step using this command:
+
+``export PL_VDS_OAUTH_TOKEN=$(plauth oauth print-access-token)``
+
+.. note::
+   The Token will expire every 3600 seconds. If that happens during a
+   session logging in again and re-setting the environment variable will fix it.
 
 .. note::
     **With the envvars set, the credentials don't have to be parsed explicitly anymore thus the syntax reduces to:**

--- a/src/vds_api_client/api_v2.py
+++ b/src/vds_api_client/api_v2.py
@@ -4,6 +4,7 @@ import sys
 import os
 import time
 from math import floor
+from typing import Optional
 from collections import OrderedDict
 import re
 from glob import glob
@@ -50,8 +51,8 @@ class VdsApiV2(VdsApiBase):
     """
         Extension of the VdsApiBase class with all api/v2 related methods
     """
-    def __init__(self, username=None, password=None, debug=True):
-        super(VdsApiV2, self).__init__(username, password, debug=debug)
+    def __init__(self, username=None, password=None, oauth_token:Optional[str]=None, debug=True):
+        super(VdsApiV2, self).__init__(username, password, oauth_token=oauth_token, debug=debug)
         self.async_requests = []
         self.uuids = []
         self._remove_after_dowload = []

--- a/src/vds_api_client/requester.py
+++ b/src/vds_api_client/requester.py
@@ -3,6 +3,7 @@ import vds_api_client as vac
 import json
 import requests
 import warnings
+from typing import Optional
 from builtins import object
 
 
@@ -19,10 +20,17 @@ class Requester(object):
         raise NotImplementedError('Call this on VdsApiV2 or VdsApiBase objects')
 
     @staticmethod
-    def set_auth(auth):
-        """Set the authentication tuple
+    def set_auth(auth, oauth_token: Optional[str] = None):
+        """Set the authentication tuple or oauth token
         """
-        vac.AUTH = auth
+        username, password = auth
+        if username and password and oauth_token:
+            raise ValueError("Use either username/password or oauth_token")
+        elif oauth_token:
+            vac.HEADERS.update({'Authorization': f'Bearer {oauth_token}'})
+            vac.AUTH = None
+        else:
+            vac.AUTH = auth
 
     @property
     def auth(self):


### PR DESCRIPTION
As a first step we implement this in the simplest way by requiring the use to get a token by themselves.

At the moment we can't unit test for this since this only works within the Planet VPN.

I tested this locally and it worked fine...